### PR TITLE
Add school list with editable form

### DIFF
--- a/CourseCorrection/ContentView.swift
+++ b/CourseCorrection/ContentView.swift
@@ -1,21 +1,52 @@
-//
-//  ContentView.swift
-//  CourseCorrection
-//
-//  Created by Davin on 6/17/25.
-//
-
 import SwiftUI
 
 struct ContentView: View {
+    @StateObject private var store = SchoolStore()
+    @State private var showingAdd = false
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        NavigationStack {
+            List {
+                ForEach($store.schools) { $school in
+                    NavigationLink(school.name) {
+                        SchoolFormView(school: $school)
+                            .navigationTitle("Edit School")
+                    }
+                }
+            }
+            .navigationTitle("Schools")
+            .toolbar {
+                Button("Add") { showingAdd = true }
+            }
+            .sheet(isPresented: $showingAdd) {
+                AddSchoolSheet()
+                    .environmentObject(store)
+            }
         }
-        .padding()
+    }
+}
+
+struct AddSchoolSheet: View {
+    @EnvironmentObject var store: SchoolStore
+    @Environment(\.dismiss) var dismiss
+    @State private var newSchool = School(name: "", location: "", type: .university)
+
+    var body: some View {
+        NavigationStack {
+            SchoolFormView(school: $newSchool)
+                .navigationTitle("New School")
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            store.schools.append(newSchool)
+                            dismiss()
+                        }
+                    }
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel", role: .cancel) { dismiss() }
+                    }
+                }
+        }
     }
 }
 

--- a/CourseCorrection/School.swift
+++ b/CourseCorrection/School.swift
@@ -1,0 +1,16 @@
+import Foundation
+import SwiftUI
+
+enum SchoolType: String, CaseIterable, Identifiable, Codable {
+    case university = "University"
+    case communityCollege = "Community College"
+
+    var id: String { rawValue }
+}
+
+struct School: Identifiable, Equatable, Codable {
+    var id: UUID = UUID()
+    var name: String
+    var location: String
+    var type: SchoolType
+}

--- a/CourseCorrection/SchoolFormView.swift
+++ b/CourseCorrection/SchoolFormView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct SchoolFormView: View {
+    @Binding var school: School
+
+    var body: some View {
+        Form {
+            TextField("Name", text: $school.name)
+            TextField("Location", text: $school.location)
+            Picker("Type", selection: $school.type) {
+                ForEach(SchoolType.allCases) { type in
+                    Text(type.rawValue).tag(type)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SchoolFormView(school: .constant(School(name: "Example", location: "", type: .university)))
+}

--- a/CourseCorrection/SchoolStore.swift
+++ b/CourseCorrection/SchoolStore.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+class SchoolStore: ObservableObject {
+    @Published var schools: [School] = []
+}


### PR DESCRIPTION
## Summary
- add `School` model with `SchoolType` enum
- add observable `SchoolStore`
- implement `SchoolFormView` for editing school details
- update `ContentView` with list, add button, and editing sheet

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6851dca67d648321b6a238aba7a5583a