### PR TITLE
Add TabView and instructor management

### DIFF
--- a/CourseCorrection/ContentView.swift
+++ b/CourseCorrection/ContentView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ContentView: View {
     @StateObject private var schoolStore = SchoolStore()
     @StateObject private var instructorStore = InstructorStore()
+    @StateObject private var departmentStore = DepartmentStore()
 
     var body: some View {
         TabView {
@@ -16,6 +17,13 @@ struct ContentView: View {
                     Label("Instructors", systemImage: "person.2")
                 }
                 .environmentObject(instructorStore)
+                .environmentObject(departmentStore)
+            DepartmentsView()
+                .tabItem {
+                    Label("Departments", systemImage: "books.vertical")
+                }
+                .environmentObject(departmentStore)
+                .environmentObject(schoolStore)
         }
     }
 }

--- a/CourseCorrection/ContentView.swift
+++ b/CourseCorrection/ContentView.swift
@@ -1,55 +1,21 @@
 import SwiftUI
 
 struct ContentView: View {
-    @StateObject private var store = SchoolStore()
-    @State private var showingAdd = false
+    @StateObject private var schoolStore = SchoolStore()
+    @StateObject private var instructorStore = InstructorStore()
 
     var body: some View {
-        NavigationStack {
-            List {
-                ForEach($store.schools) { $school in
-                    NavigationLink(school.name) {
-                        SchoolFormView(school: $school)
-                            .navigationTitle("Edit School")
-                    }
+        TabView {
+            SchoolsView()
+                .tabItem {
+                    Label("Schools", systemImage: "building.columns")
                 }
-            }
-            .navigationTitle("Schools")
-            .toolbar {
-                Button("Add") { showingAdd = true }
-            }
-            .navigationBarTitleDisplayMode(.inline)
-            .sheet(isPresented: $showingAdd) {
-                AddSchoolSheet()
-                    .environmentObject(store)
-            }
-        }
-    }
-}
-
-struct AddSchoolSheet: View {
-    @EnvironmentObject var store: SchoolStore
-    @Environment(\.dismiss) var dismiss
-    @State private var newSchool = School(name: "", location: "", type: .university)
-
-    var body: some View {
-        NavigationStack {
-            Form {
-                SchoolFormView(school: $newSchool)
-            }
-                .navigationTitle("New School")
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button("Save") {
-                            store.schools.append(newSchool)
-                            dismiss()
-                        }
-                    }
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Cancel", role: .cancel) { dismiss() }
-                    }
+                .environmentObject(schoolStore)
+            InstructorsView()
+                .tabItem {
+                    Label("Instructors", systemImage: "person.2")
                 }
+                .environmentObject(instructorStore)
         }
     }
 }

--- a/CourseCorrection/Department.swift
+++ b/CourseCorrection/Department.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Department: Identifiable, Equatable, Codable {
+    var id: UUID = UUID()
+    var name: String
+    var schoolID: UUID
+}

--- a/CourseCorrection/DepartmentFormView.swift
+++ b/CourseCorrection/DepartmentFormView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct DepartmentFormView: View {
+    @EnvironmentObject var schoolStore: SchoolStore
+    @Binding var department: Department
+
+    var body: some View {
+        Group {
+            TextField("Name", text: $department.name)
+            Picker("School", selection: $department.schoolID) {
+                ForEach(schoolStore.schools) { school in
+                    Text(school.name).tag(school.id)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    DepartmentFormView(department: .constant(Department(name: "Example", schoolID: UUID())))
+        .environmentObject(SchoolStore())
+}

--- a/CourseCorrection/DepartmentStore.swift
+++ b/CourseCorrection/DepartmentStore.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+class DepartmentStore: ObservableObject {
+    @Published var departments: [Department] = []
+}

--- a/CourseCorrection/DepartmentsView.swift
+++ b/CourseCorrection/DepartmentsView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct DepartmentsView: View {
+    @EnvironmentObject var store: DepartmentStore
+    @EnvironmentObject var schoolStore: SchoolStore
+    @State private var showingAdd = false
+
+    private var sortedDepartments: [Department] {
+        store.departments.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(sortedDepartments) { department in
+                    if let index = store.departments.firstIndex(where: { $0.id == department.id }) {
+                        NavigationLink(department.name) {
+                            DepartmentFormView(department: $store.departments[index])
+                                .environmentObject(schoolStore)
+                                .navigationTitle("Edit Department")
+                        }
+                    }
+                }
+                .onDelete(perform: deleteDepartments)
+            }
+            .navigationTitle("Departments")
+            .toolbar {
+                Button("Add") { showingAdd = true }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showingAdd) {
+                AddDepartmentSheet()
+                    .environmentObject(store)
+                    .environmentObject(schoolStore)
+            }
+        }
+    }
+
+    private func deleteDepartments(at offsets: IndexSet) {
+        for index in offsets {
+            let id = sortedDepartments[index].id
+            if let original = store.departments.firstIndex(where: { $0.id == id }) {
+                store.departments.remove(at: original)
+            }
+        }
+    }
+}
+
+struct AddDepartmentSheet: View {
+    @EnvironmentObject var store: DepartmentStore
+    @EnvironmentObject var schoolStore: SchoolStore
+    @Environment(\.dismiss) var dismiss
+    @State private var newDepartment = Department(name: "", schoolID: UUID())
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                DepartmentFormView(department: $newDepartment)
+                    .environmentObject(schoolStore)
+            }
+            .navigationTitle("New Department")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        store.departments.append(newDepartment)
+                        dismiss()
+                    }
+                    .disabled(newDepartment.name.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    DepartmentsView()
+        .environmentObject(DepartmentStore())
+        .environmentObject(SchoolStore())
+}

--- a/CourseCorrection/Instructor.swift
+++ b/CourseCorrection/Instructor.swift
@@ -1,0 +1,8 @@
+import Foundation
+import SwiftUI
+
+struct Instructor: Identifiable, Equatable, Codable {
+    var id: UUID = UUID()
+    var name: String
+    var department: String
+}

--- a/CourseCorrection/Instructor.swift
+++ b/CourseCorrection/Instructor.swift
@@ -4,5 +4,5 @@ import SwiftUI
 struct Instructor: Identifiable, Equatable, Codable {
     var id: UUID = UUID()
     var name: String
-    var department: String
+    var departments: Set<UUID>
 }

--- a/CourseCorrection/InstructorFormView.swift
+++ b/CourseCorrection/InstructorFormView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct InstructorFormView: View {
+    @Binding var instructor: Instructor
+
+    var body: some View {
+        Group {
+            TextField("Name", text: $instructor.name)
+            TextField("Department", text: $instructor.department)
+        }
+    }
+}
+
+#Preview {
+    InstructorFormView(instructor: .constant(Instructor(name: "Example", department: "Math")))
+}

--- a/CourseCorrection/InstructorFormView.swift
+++ b/CourseCorrection/InstructorFormView.swift
@@ -1,16 +1,30 @@
 import SwiftUI
 
 struct InstructorFormView: View {
+    @EnvironmentObject var departmentStore: DepartmentStore
     @Binding var instructor: Instructor
 
     var body: some View {
         Group {
             TextField("Name", text: $instructor.name)
-            TextField("Department", text: $instructor.department)
+            Section("Departments") {
+                ForEach(departmentStore.departments) { department in
+                    Toggle(department.name, isOn: Binding(
+                        get: { instructor.departments.contains(department.id) },
+                        set: { isOn in
+                            if isOn {
+                                instructor.departments.insert(department.id)
+                            } else {
+                                instructor.departments.remove(department.id)
+                            }
+                        }
+                    ))
+                }
+            }
         }
     }
 }
-
 #Preview {
-    InstructorFormView(instructor: .constant(Instructor(name: "Example", department: "Math")))
+    InstructorFormView(instructor: .constant(Instructor(name: "Example", departments: [])))
+        .environmentObject(DepartmentStore())
 }

--- a/CourseCorrection/InstructorStore.swift
+++ b/CourseCorrection/InstructorStore.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+class InstructorStore: ObservableObject {
+    @Published var instructors: [Instructor] = []
+}

--- a/CourseCorrection/InstructorsView.swift
+++ b/CourseCorrection/InstructorsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct InstructorsView: View {
     @EnvironmentObject var store: InstructorStore
+    @EnvironmentObject var departmentStore: DepartmentStore
     @State private var showingAdd = false
 
     private var sortedInstructors: [Instructor] {
@@ -15,6 +16,7 @@ struct InstructorsView: View {
                     if let index = store.instructors.firstIndex(where: { $0.id == instructor.id }) {
                         NavigationLink(instructor.name) {
                             InstructorFormView(instructor: $store.instructors[index])
+                                .environmentObject(departmentStore)
                                 .navigationTitle("Edit Instructor")
                         }
                     }
@@ -29,6 +31,7 @@ struct InstructorsView: View {
             .sheet(isPresented: $showingAdd) {
                 AddInstructorSheet()
                     .environmentObject(store)
+                    .environmentObject(departmentStore)
             }
         }
     }
@@ -45,13 +48,15 @@ struct InstructorsView: View {
 
 struct AddInstructorSheet: View {
     @EnvironmentObject var store: InstructorStore
+    @EnvironmentObject var departmentStore: DepartmentStore
     @Environment(\.dismiss) var dismiss
-    @State private var newInstructor = Instructor(name: "", department: "")
+    @State private var newInstructor = Instructor(name: "", departments: [])
 
     var body: some View {
         NavigationStack {
             Form {
                 InstructorFormView(instructor: $newInstructor)
+                    .environmentObject(departmentStore)
             }
             .navigationTitle("New Instructor")
             .navigationBarTitleDisplayMode(.inline)
@@ -72,5 +77,7 @@ struct AddInstructorSheet: View {
 }
 
 #Preview {
-    InstructorsView().environmentObject(InstructorStore())
+    InstructorsView()
+        .environmentObject(InstructorStore())
+        .environmentObject(DepartmentStore())
 }

--- a/CourseCorrection/InstructorsView.swift
+++ b/CourseCorrection/InstructorsView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct InstructorsView: View {
+    @EnvironmentObject var store: InstructorStore
+    @State private var showingAdd = false
+
+    private var sortedInstructors: [Instructor] {
+        store.instructors.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(sortedInstructors) { instructor in
+                    if let index = store.instructors.firstIndex(where: { $0.id == instructor.id }) {
+                        NavigationLink(instructor.name) {
+                            InstructorFormView(instructor: $store.instructors[index])
+                                .navigationTitle("Edit Instructor")
+                        }
+                    }
+                }
+                .onDelete(perform: deleteInstructors)
+            }
+            .navigationTitle("Instructors")
+            .toolbar {
+                Button("Add") { showingAdd = true }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showingAdd) {
+                AddInstructorSheet()
+                    .environmentObject(store)
+            }
+        }
+    }
+
+    private func deleteInstructors(at offsets: IndexSet) {
+        for index in offsets {
+            let id = sortedInstructors[index].id
+            if let original = store.instructors.firstIndex(where: { $0.id == id }) {
+                store.instructors.remove(at: original)
+            }
+        }
+    }
+}
+
+struct AddInstructorSheet: View {
+    @EnvironmentObject var store: InstructorStore
+    @Environment(\.dismiss) var dismiss
+    @State private var newInstructor = Instructor(name: "", department: "")
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                InstructorFormView(instructor: $newInstructor)
+            }
+            .navigationTitle("New Instructor")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        store.instructors.append(newInstructor)
+                        dismiss()
+                    }
+                    .disabled(newInstructor.name.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    InstructorsView().environmentObject(InstructorStore())
+}

--- a/CourseCorrection/SchoolsView.swift
+++ b/CourseCorrection/SchoolsView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+struct SchoolsView: View {
+    @EnvironmentObject var store: SchoolStore
+    @State private var showingAdd = false
+
+    private var sortedSchools: [School] {
+        store.schools.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(sortedSchools) { school in
+                    if let index = store.schools.firstIndex(where: { $0.id == school.id }) {
+                        NavigationLink(school.name) {
+                            SchoolFormView(school: $store.schools[index])
+                                .navigationTitle("Edit School")
+                        }
+                    }
+                }
+                .onDelete(perform: deleteSchools)
+            }
+            .navigationTitle("Schools")
+            .toolbar {
+                Button("Add") { showingAdd = true }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showingAdd) {
+                AddSchoolSheet()
+                    .environmentObject(store)
+            }
+        }
+    }
+
+    private func deleteSchools(at offsets: IndexSet) {
+        for index in offsets {
+            let id = sortedSchools[index].id
+            if let original = store.schools.firstIndex(where: { $0.id == id }) {
+                store.schools.remove(at: original)
+            }
+        }
+    }
+}
+
+struct AddSchoolSheet: View {
+    @EnvironmentObject var store: SchoolStore
+    @Environment(\.dismiss) var dismiss
+    @State private var newSchool = School(name: "", location: "", type: .university)
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                SchoolFormView(school: $newSchool)
+            }
+                .navigationTitle("New School")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            store.schools.append(newSchool)
+                            dismiss()
+                        }
+                        .disabled(newSchool.name.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Cancel", role: .cancel) { dismiss() }
+                    }
+                }
+        }
+    }
+}
+
+#Preview {
+    SchoolsView().environmentObject(SchoolStore())
+}


### PR DESCRIPTION
## Summary
- add `TabView` as app root to manage schools & instructors
- rename `ContentView` to `SchoolsView` and implement sorted list with deletion
- create instructor model, store, and forms for CRUD operations
- implement `InstructorsView` for listing and editing instructors
- disable save buttons when the name field is empty

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6851df8d8918832191ac1e0d439686a2