### PR TITLE
Persist data in iCloud

### DIFF
--- a/CourseCorrection/ContentView.swift
+++ b/CourseCorrection/ContentView.swift
@@ -25,6 +25,14 @@ struct ContentView: View {
                 .environmentObject(departmentStore)
                 .environmentObject(schoolStore)
         }
+        .overlay(alignment: .bottom) {
+            Text(departmentStore.usingICloud ? "Stored in iCloud" : "Stored on Device")
+                .font(.footnote)
+                .padding(6)
+                .background(.thinMaterial)
+                .cornerRadius(8)
+                .padding(.bottom, 4)
+        }
     }
 }
 

--- a/CourseCorrection/CourseCorrection.entitlements
+++ b/CourseCorrection/CourseCorrection.entitlements
@@ -2,8 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.developer.icloud-container-identifiers</key>
-	<array/>
+        <key>com.apple.developer.icloud-container-identifiers</key>
+        <array>
+                <string>iCloud.com.davin.CourseCorrection</string>
+        </array>
+        <key>com.apple.developer.icloud-services</key>
+        <array>
+                <string>CloudDocuments</string>
+        </array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>

--- a/CourseCorrection/DepartmentStore.swift
+++ b/CourseCorrection/DepartmentStore.swift
@@ -1,5 +1,54 @@
 import Foundation
 
+private let containerIdentifier = "iCloud.com.davin.CourseCorrection"
+
+/// Manages the list of `Department` objects and persists them to iCloud using
+/// `FileManager`.
 class DepartmentStore: ObservableObject {
     @Published var departments: [Department] = []
+
+    private var fileURL: URL? {
+        FileManager.default
+            .url(forUbiquityContainerIdentifier: containerIdentifier)?
+            .appendingPathComponent("departments.json")
+    }
+
+    init() {
+        load()
+    }
+
+    /// Loads stored departments from iCloud, if available.
+    func load() {
+        guard let url = fileURL,
+              let data = try? Data(contentsOf: url) else { return }
+
+        if let decoded = try? JSONDecoder().decode([Department].self, from: data) {
+            departments = decoded
+        }
+    }
+
+    /// Saves the current departments list to iCloud.
+    func save() {
+        guard let url = fileURL else { return }
+        do {
+            let data = try JSONEncoder().encode(departments)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            try data.write(to: url)
+        } catch {
+            print("Failed to save departments: \(error)")
+        }
+    }
+
+    /// Adds a department and immediately persists the change.
+    func add(_ department: Department) {
+        departments.append(department)
+        save()
+    }
+
+    /// Removes departments with the provided identifiers.
+    func remove(ids: [UUID]) {
+        departments.removeAll { ids.contains($0.id) }
+        save()
+    }
 }

--- a/CourseCorrection/InstructorStore.swift
+++ b/CourseCorrection/InstructorStore.swift
@@ -2,39 +2,41 @@ import Foundation
 
 private let containerIdentifier = "iCloud.com.davin.CourseCorrection"
 
-/// Stores `Instructor` data and persists changes in the iCloud container.
+/// Stores `Instructor` data and persists changes either in iCloud or locally.
 class InstructorStore: ObservableObject {
     @Published var instructors: [Instructor] = []
+    @Published var usingICloud: Bool
 
-    private var fileURL: URL? {
-        FileManager.default
-            .url(forUbiquityContainerIdentifier: containerIdentifier)?
-            .appendingPathComponent("instructors.json")
-    }
+    private let fileURL: URL
 
     init() {
+        if let icloud = FileManager.default.url(forUbiquityContainerIdentifier: containerIdentifier) {
+            usingICloud = true
+            fileURL = icloud.appendingPathComponent("instructors.json")
+        } else {
+            usingICloud = false
+            fileURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("instructors.json")
+        }
         load()
     }
 
-    /// Loads instructors from the iCloud container.
+    /// Loads instructors from persistent storage.
     func load() {
-        guard let url = fileURL,
-              let data = try? Data(contentsOf: url) else { return }
+        guard let data = try? Data(contentsOf: fileURL) else { return }
 
         if let decoded = try? JSONDecoder().decode([Instructor].self, from: data) {
             instructors = decoded
         }
     }
 
-    /// Saves instructors to the iCloud container.
+    /// Saves instructors to persistent storage.
     func save() {
-        guard let url = fileURL else { return }
-
         do {
             let data = try JSONEncoder().encode(instructors)
-            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+            try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(),
                                                     withIntermediateDirectories: true)
-            try data.write(to: url)
+            try data.write(to: fileURL)
         } catch {
             print("Failed to save instructors: \(error)")
         }

--- a/CourseCorrection/InstructorStore.swift
+++ b/CourseCorrection/InstructorStore.swift
@@ -1,5 +1,52 @@
 import Foundation
 
+private let containerIdentifier = "iCloud.com.davin.CourseCorrection"
+
+/// Stores `Instructor` data and persists changes in the iCloud container.
 class InstructorStore: ObservableObject {
     @Published var instructors: [Instructor] = []
+
+    private var fileURL: URL? {
+        FileManager.default
+            .url(forUbiquityContainerIdentifier: containerIdentifier)?
+            .appendingPathComponent("instructors.json")
+    }
+
+    init() {
+        load()
+    }
+
+    /// Loads instructors from the iCloud container.
+    func load() {
+        guard let url = fileURL,
+              let data = try? Data(contentsOf: url) else { return }
+
+        if let decoded = try? JSONDecoder().decode([Instructor].self, from: data) {
+            instructors = decoded
+        }
+    }
+
+    /// Saves instructors to the iCloud container.
+    func save() {
+        guard let url = fileURL else { return }
+
+        do {
+            let data = try JSONEncoder().encode(instructors)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            try data.write(to: url)
+        } catch {
+            print("Failed to save instructors: \(error)")
+        }
+    }
+
+    func add(_ instructor: Instructor) {
+        instructors.append(instructor)
+        save()
+    }
+
+    func remove(ids: [UUID]) {
+        instructors.removeAll { ids.contains($0.id) }
+        save()
+    }
 }

--- a/CourseCorrection/SchoolStore.swift
+++ b/CourseCorrection/SchoolStore.swift
@@ -1,5 +1,52 @@
 import Foundation
 
+private let containerIdentifier = "iCloud.com.davin.CourseCorrection"
+
+/// View model responsible for persisting `School` objects in iCloud.
 class SchoolStore: ObservableObject {
     @Published var schools: [School] = []
+
+    private var fileURL: URL? {
+        FileManager.default
+            .url(forUbiquityContainerIdentifier: containerIdentifier)?
+            .appendingPathComponent("schools.json")
+    }
+
+    init() {
+        load()
+    }
+
+    /// Loads schools from the iCloud container.
+    func load() {
+        guard let url = fileURL,
+              let data = try? Data(contentsOf: url) else { return }
+
+        if let decoded = try? JSONDecoder().decode([School].self, from: data) {
+            schools = decoded
+        }
+    }
+
+    /// Saves schools to the iCloud container.
+    func save() {
+        guard let url = fileURL else { return }
+
+        do {
+            let data = try JSONEncoder().encode(schools)
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            try data.write(to: url)
+        } catch {
+            print("Failed to save schools: \(error)")
+        }
+    }
+
+    func add(_ school: School) {
+        schools.append(school)
+        save()
+    }
+
+    func remove(ids: [UUID]) {
+        schools.removeAll { ids.contains($0.id) }
+        save()
+    }
 }


### PR DESCRIPTION
## Summary
- add iCloud container to app entitlements
- store Departments, Instructors and Schools on iCloud using FileManager
- provide add/delete helpers that save data
- call save when editing items or adding/removing them
- edit views now present Save and Cancel buttons

## Testing
- `swift --version`
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6851ed8498708321ace86c9d93ea2e72