### PR TITLE
Add Semester store and update school details

### DIFF
--- a/CourseCorrection/ContentView.swift
+++ b/CourseCorrection/ContentView.swift
@@ -4,6 +4,7 @@ struct ContentView: View {
     @StateObject private var schoolStore = SchoolStore()
     @StateObject private var instructorStore = InstructorStore()
     @StateObject private var departmentStore = DepartmentStore()
+    @StateObject private var semesterStore = SemesterStore()
 
     var body: some View {
         TabView {
@@ -12,6 +13,7 @@ struct ContentView: View {
                     Label("Schools", systemImage: "building.columns")
                 }
                 .environmentObject(schoolStore)
+                .environmentObject(semesterStore)
             InstructorsView()
                 .tabItem {
                     Label("Instructors", systemImage: "person.2")

--- a/CourseCorrection/DateComponentsPicker.swift
+++ b/CourseCorrection/DateComponentsPicker.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// A picker that binds to ``DateComponents`` allowing selection of month,
+/// day and year. It automatically adjusts the available days when the
+/// month or year changes so that invalid dates are never selected.
+struct DateComponentsPicker: View {
+    @Binding var components: DateComponents
+
+    private var monthNames: [String] { Calendar.current.monthSymbols }
+
+    private var daysInCurrentMonth: Int {
+        let calendar = Calendar.current
+        var comps = DateComponents()
+        comps.year = components.year ?? 2000
+        comps.month = components.month ?? 1
+        // Default to day 1 to calculate the range for the given month/year
+        comps.day = 1
+        if let date = calendar.date(from: comps),
+           let range = calendar.range(of: .day, in: .month, for: date) {
+            return range.count
+        }
+        return 31
+    }
+
+    private func adjustDayIfNeeded() {
+        if let day = components.day, day > daysInCurrentMonth {
+            components.day = daysInCurrentMonth
+        }
+    }
+
+    var body: some View {
+        HStack {
+            Picker("Month", selection: Binding(
+                get: { components.month ?? 1 },
+                set: { newMonth in
+                    components.month = newMonth
+                    adjustDayIfNeeded()
+                })) {
+                    ForEach(1...12, id: \..self) { month in
+                        Text(monthNames[month - 1]).tag(month)
+                    }
+                }
+            Picker("Day", selection: Binding(
+                get: { components.day ?? 1 },
+                set: { newDay in components.day = newDay })) {
+                    ForEach(1...daysInCurrentMonth, id: \..self) { day in
+                        Text(String(day)).tag(day)
+                    }
+                }
+            let currentYear = Calendar.current.component(.year, from: Date())
+            Picker("Year", selection: Binding(
+                get: { components.year ?? currentYear },
+                set: { newYear in
+                    components.year = newYear
+                    adjustDayIfNeeded()
+                })) {
+                    ForEach((currentYear - 100)...(currentYear + 20), id: \..self) { year in
+                        Text(String(year)).tag(year)
+                    }
+                }
+        }
+    }
+}
+
+#Preview {
+    DateComponentsPicker(components: .constant(DateComponents(year: 2024, month: 2, day: 29)))
+        .padding()
+}

--- a/CourseCorrection/SchoolDetailView.swift
+++ b/CourseCorrection/SchoolDetailView.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+
+/// Displays the details of a ``School`` and allows editing the record.
+struct SchoolDetailView: View {
+    @EnvironmentObject var store: SchoolStore
+    @EnvironmentObject var semesterStore: SemesterStore
+    let school: School
+    @State private var showingEdit = false
+    @State private var showingAddSemester = false
+
+    private var semestersForSchool: [Semester] {
+        semesterStore.semesters
+            .filter { $0.schoolID == school.id }
+            .sorted { sortValue(for: $0.startDate) > sortValue(for: $1.startDate) }
+    }
+
+    var body: some View {
+        Form {
+            Section("Details") {
+                Text(school.name)
+                Text(school.location)
+                Text(school.type.rawValue)
+            }
+
+            Section("Semesters") {
+                if semestersForSchool.isEmpty {
+                    Text("No Semesters")
+                        .foregroundStyle(.secondary)
+                } else {
+                    ForEach(semestersForSchool) { semester in
+                        NavigationLink {
+                            EditSemesterView(semester: semester)
+                                .environmentObject(semesterStore)
+                                .environmentObject(store)
+                        } label: {
+                            VStack(alignment: .leading) {
+                                Text(semester.name)
+                                Text("\(format(semester.startDate)) - \(format(semester.endDate))")
+                                    .font(.footnote)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                    .onDelete(perform: deleteSemesters)
+                }
+            }
+        }
+        .navigationTitle(school.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button("Add Semester") { showingAddSemester = true }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Edit") { showingEdit = true }
+            }
+        }
+        .sheet(isPresented: $showingEdit) {
+            EditSchoolView(school: school)
+                .environmentObject(store)
+        }
+        .sheet(isPresented: $showingAddSemester) {
+            AddSemesterSheet(schoolID: school.id)
+                .environmentObject(semesterStore)
+                .environmentObject(store)
+        }
+    }
+
+    private func format(_ components: DateComponents) -> String {
+        var parts: [String] = []
+        if let month = components.month {
+            parts.append(Calendar.current.monthSymbols[month - 1])
+        }
+        if let day = components.day {
+            parts.append(String(day))
+        }
+        if let year = components.year {
+            parts.append(String(year))
+        }
+        return parts.joined(separator: " ")
+    }
+
+    private func deleteSemesters(at offsets: IndexSet) {
+        let ids = offsets.map { semestersForSchool[$0].id }
+        semesterStore.remove(ids: ids)
+    }
+
+    private func sortValue(for components: DateComponents) -> Int {
+        let year = components.year ?? 0
+        let month = components.month ?? 0
+        let day = components.day ?? 0
+        return year * 10000 + month * 100 + day
+    }
+}
+
+struct AddSemesterSheet: View {
+    @EnvironmentObject var semesterStore: SemesterStore
+    @EnvironmentObject var schoolStore: SchoolStore
+    @Environment(\.dismiss) var dismiss
+
+    @State private var newSemester: Semester
+
+    init(schoolID: UUID) {
+        _newSemester = State(initialValue: Semester(name: "", schoolID: schoolID, startDate: DateComponents(), endDate: DateComponents()))
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                SemesterFormView(semester: $newSemester)
+                    .environmentObject(schoolStore)
+            }
+            .navigationTitle("New Semester")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        semesterStore.add(newSemester)
+                        dismiss()
+                    }
+                    .disabled(newSemester.name.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+struct EditSemesterView: View {
+    @EnvironmentObject var semesterStore: SemesterStore
+    @EnvironmentObject var schoolStore: SchoolStore
+    @Environment(\.dismiss) var dismiss
+
+    @State private var editedSemester: Semester
+    private let originalSemester: Semester
+
+    init(semester: Semester) {
+        _editedSemester = State(initialValue: semester)
+        self.originalSemester = semester
+    }
+
+    var body: some View {
+        Form {
+            SemesterFormView(semester: $editedSemester)
+                .environmentObject(schoolStore)
+        }
+        .navigationTitle("Edit Semester")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") { save() }
+                    .disabled(editedSemester == originalSemester)
+            }
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel", role: .cancel) { dismiss() }
+            }
+        }
+    }
+
+    private func save() {
+        if let index = semesterStore.semesters.firstIndex(where: { $0.id == originalSemester.id }) {
+            semesterStore.semesters[index] = editedSemester
+            semesterStore.save()
+        }
+        dismiss()
+    }
+}
+
+#Preview {
+    SchoolDetailView(school: School(name: "Example", location: "", type: .university))
+        .environmentObject(SchoolStore())
+        .environmentObject(SemesterStore())
+}

--- a/CourseCorrection/SchoolsView.swift
+++ b/CourseCorrection/SchoolsView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct SchoolsView: View {
     @EnvironmentObject var store: SchoolStore
+    @EnvironmentObject var semesterStore: SemesterStore
     @State private var showingAdd = false
     @State private var searchText = ""
 
@@ -22,8 +23,9 @@ struct SchoolsView: View {
                 ForEach(filteredSchools) { school in
                     if let _ = store.schools.firstIndex(where: { $0.id == school.id }) {
                         NavigationLink(school.name) {
-                            EditSchoolView(school: school)
+                            SchoolDetailView(school: school)
                                 .environmentObject(store)
+                                .environmentObject(semesterStore)
                         }
                     }
                 }

--- a/CourseCorrection/Semester.swift
+++ b/CourseCorrection/Semester.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct Semester: Identifiable, Equatable, Codable {
+    var id: UUID = UUID()
+    var name: String
+    var schoolID: UUID
+    var startDate: DateComponents
+    var endDate: DateComponents
+}

--- a/CourseCorrection/SemesterFormView.swift
+++ b/CourseCorrection/SemesterFormView.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct SemesterFormView: View {
+    @EnvironmentObject var schoolStore: SchoolStore
+    @Binding var semester: Semester
+
+    var body: some View {
+        Group {
+            TextField("Name", text: $semester.name)
+            Picker("School", selection: $semester.schoolID) {
+                ForEach(schoolStore.schools) { school in
+                    Text(school.name).tag(school.id)
+                }
+            }
+            Section("Start Date") {
+                DateComponentsPicker(components: $semester.startDate)
+            }
+            Section("End Date") {
+                DateComponentsPicker(components: $semester.endDate)
+            }
+        }
+    }
+}
+
+#Preview {
+    SemesterFormView(semester: .constant(Semester(name: "Fall", schoolID: UUID(), startDate: DateComponents(year: 2024, month: 8, day: 20), endDate: DateComponents(year: 2024, month: 12, day: 15))))
+        .environmentObject(SchoolStore())
+}

--- a/CourseCorrection/SemesterStore.swift
+++ b/CourseCorrection/SemesterStore.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+private let containerIdentifier = "iCloud.com.davin.CourseCorrection"
+
+/// Stores `Semester` objects and persists them either in iCloud or locally.
+class SemesterStore: ObservableObject {
+    @Published var semesters: [Semester] = []
+    @Published var usingICloud: Bool
+
+    private let fileURL: URL
+
+    init() {
+        if let icloud = FileManager.default.url(forUbiquityContainerIdentifier: containerIdentifier) {
+            usingICloud = true
+            fileURL = icloud.appendingPathComponent("semesters.json")
+        } else {
+            usingICloud = false
+            fileURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("semesters.json")
+        }
+        load()
+    }
+
+    /// Loads semesters from persistent storage.
+    func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+
+        if let decoded = try? JSONDecoder().decode([Semester].self, from: data) {
+            semesters = decoded
+        }
+    }
+
+    /// Saves semesters to persistent storage.
+    func save() {
+        do {
+            let data = try JSONEncoder().encode(semesters)
+            try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(),
+                                                    withIntermediateDirectories: true)
+            try data.write(to: fileURL)
+        } catch {
+            print("Failed to save semesters: \(error)")
+        }
+    }
+
+    /// Adds a semester and immediately persists the change.
+    func add(_ semester: Semester) {
+        semesters.append(semester)
+        save()
+    }
+
+    /// Removes semesters with the provided identifiers.
+    func remove(ids: [UUID]) {
+        semesters.removeAll { ids.contains($0.id) }
+        save()
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SemesterStore` for persisting semesters
- inject semester store into `ContentView` and `SchoolsView`
- show semesters in `SchoolDetailView` with dedicated sections
- add navigation to edit semesters and ability to add or delete them

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list -project CourseCorrection.xcodeproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f74c6cc88321994a81764f499f8d