### PR TITLE
Add Subject, Course and Class models

### DIFF
--- a/CourseCorrection/ClassItem.swift
+++ b/CourseCorrection/ClassItem.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct ClassItem: Identifiable, Equatable, Codable {
+    var id: UUID = UUID()
+    var courseID: UUID
+    var semesterID: UUID?
+    var instructorID: UUID?
+}

--- a/CourseCorrection/ClassItemFormView.swift
+++ b/CourseCorrection/ClassItemFormView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+struct ClassItemFormView: View {
+    @EnvironmentObject var courseStore: CourseStore
+    @EnvironmentObject var instructorStore: InstructorStore
+    @Binding var classItem: ClassItem
+
+    @State private var semesterIDText: String = ""
+
+    var body: some View {
+        Group {
+            Picker("Course", selection: $classItem.courseID) {
+                ForEach(courseStore.courses) { course in
+                    Text("\(course.courseNumber) - \(course.title)").tag(course.id)
+                }
+            }
+            TextField("Semester ID", text: Binding(
+                get: { classItem.semesterID?.uuidString ?? "" },
+                set: { classItem.semesterID = UUID(uuidString: $0) }
+            ))
+            Picker("Instructor", selection: $classItem.instructorID) {
+                Text("None").tag(nil as UUID?)
+                ForEach(instructorStore.instructors) { instructor in
+                    Text(instructor.name).tag(Optional(instructor.id))
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    ClassItemFormView(classItem: .constant(ClassItem(courseID: UUID(), semesterID: nil, instructorID: nil)))
+        .environmentObject(CourseStore())
+        .environmentObject(InstructorStore())
+}

--- a/CourseCorrection/ClassItemStore.swift
+++ b/CourseCorrection/ClassItemStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+private let containerIdentifier = "iCloud.com.davin.CourseCorrection"
+
+class ClassItemStore: ObservableObject {
+    @Published var classItems: [ClassItem] = []
+    @Published var usingICloud: Bool
+
+    private let fileURL: URL
+
+    init() {
+        if let icloud = FileManager.default.url(forUbiquityContainerIdentifier: containerIdentifier) {
+            usingICloud = true
+            fileURL = icloud.appendingPathComponent("class_items.json")
+        } else {
+            usingICloud = false
+            fileURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("class_items.json")
+        }
+        load()
+    }
+
+    func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+
+        if let decoded = try? JSONDecoder().decode([ClassItem].self, from: data) {
+            classItems = decoded
+        }
+    }
+
+    func save() {
+        do {
+            let data = try JSONEncoder().encode(classItems)
+            try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: fileURL)
+        } catch {
+            print("Failed to save class items: \(error)")
+        }
+    }
+
+    func add(_ classItem: ClassItem) {
+        classItems.append(classItem)
+        save()
+    }
+
+    func remove(ids: [UUID]) {
+        classItems.removeAll { ids.contains($0.id) }
+        save()
+    }
+}

--- a/CourseCorrection/ClassItemsView.swift
+++ b/CourseCorrection/ClassItemsView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+
+struct ClassItemsView: View {
+    @EnvironmentObject var store: ClassItemStore
+    @EnvironmentObject var courseStore: CourseStore
+    @EnvironmentObject var instructorStore: InstructorStore
+    @State private var showingAdd = false
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(store.classItems) { item in
+                    if let course = courseStore.courses.first(where: { $0.id == item.courseID }),
+                       let index = store.classItems.firstIndex(where: { $0.id == item.id }) {
+                        NavigationLink("\(course.courseNumber) - \(course.title)") {
+                            EditClassItemView(classItem: item)
+                                .environmentObject(store)
+                                .environmentObject(courseStore)
+                                .environmentObject(instructorStore)
+                        }
+                    }
+                }
+                .onDelete(perform: deleteItems)
+            }
+            .overlay {
+                if store.classItems.isEmpty {
+                    ContentUnavailableView("No Classes", systemImage: "calendar")
+                }
+            }
+            .navigationTitle("Classes")
+            .toolbar { Button("Add") { showingAdd = true } }
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showingAdd) {
+                AddClassItemSheet()
+                    .environmentObject(store)
+                    .environmentObject(courseStore)
+                    .environmentObject(instructorStore)
+            }
+        }
+    }
+
+    private func deleteItems(at offsets: IndexSet) {
+        let ids = offsets.map { store.classItems[$0].id }
+        store.remove(ids: ids)
+    }
+}
+
+struct AddClassItemSheet: View {
+    @EnvironmentObject var store: ClassItemStore
+    @EnvironmentObject var courseStore: CourseStore
+    @EnvironmentObject var instructorStore: InstructorStore
+    @Environment(\.dismiss) var dismiss
+    @State private var newItem = ClassItem(courseID: UUID(), semesterID: nil, instructorID: nil)
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                ClassItemFormView(classItem: $newItem)
+                    .environmentObject(courseStore)
+                    .environmentObject(instructorStore)
+            }
+            .navigationTitle("New Class")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        store.add(newItem)
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+struct EditClassItemView: View {
+    @EnvironmentObject var store: ClassItemStore
+    @EnvironmentObject var courseStore: CourseStore
+    @EnvironmentObject var instructorStore: InstructorStore
+    @Environment(\.dismiss) var dismiss
+
+    @State private var editedItem: ClassItem
+    private let originalItem: ClassItem
+
+    init(classItem: ClassItem) {
+        self._editedItem = State(initialValue: classItem)
+        self.originalItem = classItem
+    }
+
+    var body: some View {
+        Form {
+            ClassItemFormView(classItem: $editedItem)
+                .environmentObject(courseStore)
+                .environmentObject(instructorStore)
+        }
+        .navigationTitle("Edit Class")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") { save() }
+                    .disabled(editedItem == originalItem)
+            }
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel", role: .cancel) { dismiss() }
+            }
+        }
+    }
+
+    private func save() {
+        if let index = store.classItems.firstIndex(where: { $0.id == originalItem.id }) {
+            store.classItems[index] = editedItem
+            store.save()
+        }
+        dismiss()
+    }
+}
+
+#Preview {
+    ClassItemsView()
+        .environmentObject(ClassItemStore())
+        .environmentObject(CourseStore())
+        .environmentObject(InstructorStore())
+}

--- a/CourseCorrection/ContentView.swift
+++ b/CourseCorrection/ContentView.swift
@@ -4,6 +4,9 @@ struct ContentView: View {
     @StateObject private var schoolStore = SchoolStore()
     @StateObject private var instructorStore = InstructorStore()
     @StateObject private var departmentStore = DepartmentStore()
+    @StateObject private var subjectStore = SubjectStore()
+    @StateObject private var courseStore = CourseStore()
+    @StateObject private var classItemStore = ClassItemStore()
 
     var body: some View {
         TabView {
@@ -24,6 +27,25 @@ struct ContentView: View {
                 }
                 .environmentObject(departmentStore)
                 .environmentObject(schoolStore)
+            SubjectsView()
+                .tabItem {
+                    Label("Subjects", systemImage: "book")
+                }
+                .environmentObject(subjectStore)
+                .environmentObject(schoolStore)
+            CoursesView()
+                .tabItem {
+                    Label("Courses", systemImage: "book.closed")
+                }
+                .environmentObject(courseStore)
+                .environmentObject(subjectStore)
+            ClassItemsView()
+                .tabItem {
+                    Label("Classes", systemImage: "calendar")
+                }
+                .environmentObject(classItemStore)
+                .environmentObject(courseStore)
+                .environmentObject(instructorStore)
         }
         .overlay(alignment: .bottom) {
             Text(departmentStore.usingICloud ? "Stored in iCloud" : "Stored on Device")

--- a/CourseCorrection/Course.swift
+++ b/CourseCorrection/Course.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct Course: Identifiable, Equatable, Codable {
+    var id: UUID = UUID()
+    var subjectID: UUID
+    var courseNumber: String
+    var title: String
+    var description: String
+    var units: Int
+}

--- a/CourseCorrection/CourseFormView.swift
+++ b/CourseCorrection/CourseFormView.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+struct CourseFormView: View {
+    @EnvironmentObject var subjectStore: SubjectStore
+    @Binding var course: Course
+
+    var body: some View {
+        Group {
+            Picker("Subject", selection: $course.subjectID) {
+                ForEach(subjectStore.subjects) { subject in
+                    Text(subject.name).tag(subject.id)
+                }
+            }
+            TextField("Course Number", text: $course.courseNumber)
+            TextField("Title", text: $course.title)
+            TextField("Description", text: $course.description)
+            Stepper(value: $course.units, in: 0...20) {
+                Text("Units: \(course.units)")
+            }
+        }
+    }
+}
+
+#Preview {
+    CourseFormView(course: .constant(Course(subjectID: UUID(), courseNumber: "101", title: "Example", description: "", units: 3)))
+        .environmentObject(SubjectStore())
+}

--- a/CourseCorrection/CourseStore.swift
+++ b/CourseCorrection/CourseStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+private let containerIdentifier = "iCloud.com.davin.CourseCorrection"
+
+class CourseStore: ObservableObject {
+    @Published var courses: [Course] = []
+    @Published var usingICloud: Bool
+
+    private let fileURL: URL
+
+    init() {
+        if let icloud = FileManager.default.url(forUbiquityContainerIdentifier: containerIdentifier) {
+            usingICloud = true
+            fileURL = icloud.appendingPathComponent("courses.json")
+        } else {
+            usingICloud = false
+            fileURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("courses.json")
+        }
+        load()
+    }
+
+    func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+
+        if let decoded = try? JSONDecoder().decode([Course].self, from: data) {
+            courses = decoded
+        }
+    }
+
+    func save() {
+        do {
+            let data = try JSONEncoder().encode(courses)
+            try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: fileURL)
+        } catch {
+            print("Failed to save courses: \(error)")
+        }
+    }
+
+    func add(_ course: Course) {
+        courses.append(course)
+        save()
+    }
+
+    func remove(ids: [UUID]) {
+        courses.removeAll { ids.contains($0.id) }
+        save()
+    }
+}

--- a/CourseCorrection/CoursesView.swift
+++ b/CourseCorrection/CoursesView.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+
+struct CoursesView: View {
+    @EnvironmentObject var store: CourseStore
+    @EnvironmentObject var subjectStore: SubjectStore
+    @State private var showingAdd = false
+    @State private var searchText = ""
+
+    private var sortedCourses: [Course] {
+        store.courses.sorted { $0.courseNumber.localizedCaseInsensitiveCompare($1.courseNumber) == .orderedAscending }
+    }
+
+    private var filteredCourses: [Course] {
+        guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return sortedCourses
+        }
+        return sortedCourses.filter { $0.title.localizedCaseInsensitiveContains(searchText) || $0.courseNumber.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(filteredCourses) { course in
+                    if let _ = store.courses.firstIndex(where: { $0.id == course.id }) {
+                        NavigationLink("\(course.courseNumber) - \(course.title)") {
+                            EditCourseView(course: course)
+                                .environmentObject(store)
+                                .environmentObject(subjectStore)
+                        }
+                    }
+                }
+                .onDelete(perform: deleteCourses)
+            }
+            .overlay {
+                if sortedCourses.isEmpty {
+                    ContentUnavailableView("No Courses", systemImage: "book")
+                }
+            }
+            .navigationTitle("Courses")
+            .toolbar { Button("Add") { showingAdd = true } }
+            .searchable(text: $searchText)
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showingAdd) {
+                AddCourseSheet()
+                    .environmentObject(store)
+                    .environmentObject(subjectStore)
+            }
+        }
+    }
+
+    private func deleteCourses(at offsets: IndexSet) {
+        let ids = offsets.map { filteredCourses[$0].id }
+        store.remove(ids: ids)
+    }
+}
+
+struct AddCourseSheet: View {
+    @EnvironmentObject var store: CourseStore
+    @EnvironmentObject var subjectStore: SubjectStore
+    @Environment(\.dismiss) var dismiss
+    @State private var newCourse = Course(subjectID: UUID(), courseNumber: "", title: "", description: "", units: 0)
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                CourseFormView(course: $newCourse)
+                    .environmentObject(subjectStore)
+            }
+            .navigationTitle("New Course")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        store.add(newCourse)
+                        dismiss()
+                    }
+                    .disabled(newCourse.title.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+struct EditCourseView: View {
+    @EnvironmentObject var store: CourseStore
+    @EnvironmentObject var subjectStore: SubjectStore
+    @Environment(\.dismiss) var dismiss
+
+    @State private var editedCourse: Course
+    private let originalCourse: Course
+
+    init(course: Course) {
+        self._editedCourse = State(initialValue: course)
+        self.originalCourse = course
+    }
+
+    var body: some View {
+        Form {
+            CourseFormView(course: $editedCourse)
+                .environmentObject(subjectStore)
+        }
+        .navigationTitle("Edit Course")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") { save() }
+                    .disabled(editedCourse == originalCourse)
+            }
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel", role: .cancel) { dismiss() }
+            }
+        }
+    }
+
+    private func save() {
+        if let index = store.courses.firstIndex(where: { $0.id == originalCourse.id }) {
+            store.courses[index] = editedCourse
+            store.save()
+        }
+        dismiss()
+    }
+}
+
+#Preview {
+    CoursesView()
+        .environmentObject(CourseStore())
+        .environmentObject(SubjectStore())
+}

--- a/CourseCorrection/Subject.swift
+++ b/CourseCorrection/Subject.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct Subject: Identifiable, Equatable, Codable {
+    var id: UUID = UUID()
+    var name: String
+    var schoolID: UUID
+}

--- a/CourseCorrection/SubjectFormView.swift
+++ b/CourseCorrection/SubjectFormView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct SubjectFormView: View {
+    @EnvironmentObject var schoolStore: SchoolStore
+    @Binding var subject: Subject
+
+    var body: some View {
+        Group {
+            TextField("Name", text: $subject.name)
+            Picker("School", selection: $subject.schoolID) {
+                ForEach(schoolStore.schools) { school in
+                    Text(school.name).tag(school.id)
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    SubjectFormView(subject: .constant(Subject(name: "Example", schoolID: UUID())))
+        .environmentObject(SchoolStore())
+}

--- a/CourseCorrection/SubjectStore.swift
+++ b/CourseCorrection/SubjectStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+private let containerIdentifier = "iCloud.com.davin.CourseCorrection"
+
+class SubjectStore: ObservableObject {
+    @Published var subjects: [Subject] = []
+    @Published var usingICloud: Bool
+
+    private let fileURL: URL
+
+    init() {
+        if let icloud = FileManager.default.url(forUbiquityContainerIdentifier: containerIdentifier) {
+            usingICloud = true
+            fileURL = icloud.appendingPathComponent("subjects.json")
+        } else {
+            usingICloud = false
+            fileURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("subjects.json")
+        }
+        load()
+    }
+
+    func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+
+        if let decoded = try? JSONDecoder().decode([Subject].self, from: data) {
+            subjects = decoded
+        }
+    }
+
+    func save() {
+        do {
+            let data = try JSONEncoder().encode(subjects)
+            try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: fileURL)
+        } catch {
+            print("Failed to save subjects: \(error)")
+        }
+    }
+
+    func add(_ subject: Subject) {
+        subjects.append(subject)
+        save()
+    }
+
+    func remove(ids: [UUID]) {
+        subjects.removeAll { ids.contains($0.id) }
+        save()
+    }
+}

--- a/CourseCorrection/SubjectsView.swift
+++ b/CourseCorrection/SubjectsView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+struct SubjectsView: View {
+    @EnvironmentObject var store: SubjectStore
+    @EnvironmentObject var schoolStore: SchoolStore
+    @State private var showingAdd = false
+    @State private var searchText = ""
+
+    private var sortedSubjects: [Subject] {
+        store.subjects.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    private var filteredSubjects: [Subject] {
+        guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return sortedSubjects
+        }
+        return sortedSubjects.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
+    private var sortedSchools: [School] {
+        schoolStore.schools.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    private func subjects(for school: School) -> [Subject] {
+        filteredSubjects.filter { $0.schoolID == school.id }
+    }
+
+    private var unknownSubjects: [Subject] {
+        filteredSubjects.filter { subj in
+            !schoolStore.schools.contains(where: { $0.id == subj.schoolID })
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(sortedSchools) { school in
+                    if !subjects(for: school).isEmpty {
+                        Section(header: Text(school.name)) {
+                            ForEach(subjects(for: school)) { subject in
+                                if let index = store.subjects.firstIndex(where: { $0.id == subject.id }) {
+                                    NavigationLink(subject.name) {
+                                        EditSubjectView(subject: subject)
+                                            .environmentObject(store)
+                                            .environmentObject(schoolStore)
+                                    }
+                                }
+                            }
+                            .onDelete { offsets in
+                                deleteSubjects(at: offsets, in: subjects(for: school))
+                            }
+                        }
+                    }
+                }
+
+                if !unknownSubjects.isEmpty {
+                    Section(header: Text("Unknown School")) {
+                        ForEach(unknownSubjects) { subject in
+                            if let _ = store.subjects.firstIndex(where: { $0.id == subject.id }) {
+                                NavigationLink(subject.name) {
+                                    EditSubjectView(subject: subject)
+                                        .environmentObject(store)
+                                        .environmentObject(schoolStore)
+                                }
+                            }
+                        }
+                        .onDelete { offsets in
+                            deleteSubjects(at: offsets, in: unknownSubjects)
+                        }
+                    }
+                }
+            }
+            .overlay {
+                if sortedSubjects.isEmpty {
+                    ContentUnavailableView("No Subjects", systemImage: "book")
+                }
+            }
+            .navigationTitle("Subjects")
+            .toolbar {
+                Button("Add") { showingAdd = true }
+            }
+            .searchable(text: $searchText)
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showingAdd) {
+                AddSubjectSheet()
+                    .environmentObject(store)
+                    .environmentObject(schoolStore)
+            }
+        }
+    }
+
+    private func deleteSubjects(at offsets: IndexSet, in list: [Subject]) {
+        let ids = offsets.map { list[$0].id }
+        store.remove(ids: ids)
+    }
+}
+
+struct AddSubjectSheet: View {
+    @EnvironmentObject var store: SubjectStore
+    @EnvironmentObject var schoolStore: SchoolStore
+    @Environment(\.dismiss) var dismiss
+    @State private var newSubject = Subject(name: "", schoolID: UUID())
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                SubjectFormView(subject: $newSubject)
+                    .environmentObject(schoolStore)
+            }
+            .navigationTitle("New Subject")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        store.add(newSubject)
+                        dismiss()
+                    }
+                    .disabled(newSubject.name.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+struct EditSubjectView: View {
+    @EnvironmentObject var store: SubjectStore
+    @EnvironmentObject var schoolStore: SchoolStore
+    @Environment(\.dismiss) var dismiss
+
+    @State private var editedSubject: Subject
+    private let originalSubject: Subject
+
+    init(subject: Subject) {
+        self._editedSubject = State(initialValue: subject)
+        self.originalSubject = subject
+    }
+
+    var body: some View {
+        Form {
+            SubjectFormView(subject: $editedSubject)
+                .environmentObject(schoolStore)
+        }
+        .navigationTitle("Edit Subject")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") { save() }
+                    .disabled(editedSubject == originalSubject)
+            }
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel", role: .cancel) { dismiss() }
+            }
+        }
+    }
+
+    private func save() {
+        if let index = store.subjects.firstIndex(where: { $0.id == originalSubject.id }) {
+            store.subjects[index] = editedSubject
+            store.save()
+        }
+        dismiss()
+    }
+}
+
+#Preview {
+    SubjectsView()
+        .environmentObject(SubjectStore())
+        .environmentObject(SchoolStore())
+}


### PR DESCRIPTION
## Summary
- create data models for Subject, Course and ClassItem
- add respective stores and forms
- add list views for each new entity
- integrate new tabs for Subjects, Courses and Classes in `ContentView`

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68520e5f08288321b0b2a0994be3e9ac