### PR TITLE
Enable semester selection for class items

### DIFF
--- a/CourseCorrection/ClassItemFormView.swift
+++ b/CourseCorrection/ClassItemFormView.swift
@@ -3,9 +3,8 @@ import SwiftUI
 struct ClassItemFormView: View {
     @EnvironmentObject var courseStore: CourseStore
     @EnvironmentObject var instructorStore: InstructorStore
+    @EnvironmentObject var semesterStore: SemesterStore
     @Binding var classItem: ClassItem
-
-    @State private var semesterIDText: String = ""
 
     var body: some View {
         Group {
@@ -14,10 +13,12 @@ struct ClassItemFormView: View {
                     Text("\(course.courseNumber) - \(course.title)").tag(course.id)
                 }
             }
-            TextField("Semester ID", text: Binding(
-                get: { classItem.semesterID?.uuidString ?? "" },
-                set: { classItem.semesterID = UUID(uuidString: $0) }
-            ))
+            Picker("Semester", selection: $classItem.semesterID) {
+                Text("None").tag(nil as UUID?)
+                ForEach(semesterStore.semesters) { semester in
+                    Text(semester.name).tag(Optional(semester.id))
+                }
+            }
             Picker("Instructor", selection: $classItem.instructorID) {
                 Text("None").tag(nil as UUID?)
                 ForEach(instructorStore.instructors) { instructor in
@@ -32,4 +33,5 @@ struct ClassItemFormView: View {
     ClassItemFormView(classItem: .constant(ClassItem(courseID: UUID(), semesterID: nil, instructorID: nil)))
         .environmentObject(CourseStore())
         .environmentObject(InstructorStore())
+        .environmentObject(SemesterStore())
 }

--- a/CourseCorrection/ClassItemsView.swift
+++ b/CourseCorrection/ClassItemsView.swift
@@ -4,6 +4,7 @@ struct ClassItemsView: View {
     @EnvironmentObject var store: ClassItemStore
     @EnvironmentObject var courseStore: CourseStore
     @EnvironmentObject var instructorStore: InstructorStore
+    @EnvironmentObject var semesterStore: SemesterStore
     @State private var showingAdd = false
 
     var body: some View {
@@ -17,6 +18,7 @@ struct ClassItemsView: View {
                                 .environmentObject(store)
                                 .environmentObject(courseStore)
                                 .environmentObject(instructorStore)
+                                .environmentObject(semesterStore)
                         }
                     }
                 }
@@ -35,6 +37,7 @@ struct ClassItemsView: View {
                     .environmentObject(store)
                     .environmentObject(courseStore)
                     .environmentObject(instructorStore)
+                    .environmentObject(semesterStore)
             }
         }
     }
@@ -49,6 +52,7 @@ struct AddClassItemSheet: View {
     @EnvironmentObject var store: ClassItemStore
     @EnvironmentObject var courseStore: CourseStore
     @EnvironmentObject var instructorStore: InstructorStore
+    @EnvironmentObject var semesterStore: SemesterStore
     @Environment(\.dismiss) var dismiss
     @State private var newItem = ClassItem(courseID: UUID(), semesterID: nil, instructorID: nil)
 
@@ -58,6 +62,7 @@ struct AddClassItemSheet: View {
                 ClassItemFormView(classItem: $newItem)
                     .environmentObject(courseStore)
                     .environmentObject(instructorStore)
+                    .environmentObject(semesterStore)
             }
             .navigationTitle("New Class")
             .navigationBarTitleDisplayMode(.inline)
@@ -80,6 +85,7 @@ struct EditClassItemView: View {
     @EnvironmentObject var store: ClassItemStore
     @EnvironmentObject var courseStore: CourseStore
     @EnvironmentObject var instructorStore: InstructorStore
+    @EnvironmentObject var semesterStore: SemesterStore
     @Environment(\.dismiss) var dismiss
 
     @State private var editedItem: ClassItem
@@ -95,6 +101,7 @@ struct EditClassItemView: View {
             ClassItemFormView(classItem: $editedItem)
                 .environmentObject(courseStore)
                 .environmentObject(instructorStore)
+                .environmentObject(semesterStore)
         }
         .navigationTitle("Edit Class")
         .navigationBarTitleDisplayMode(.inline)
@@ -123,4 +130,5 @@ struct EditClassItemView: View {
         .environmentObject(ClassItemStore())
         .environmentObject(CourseStore())
         .environmentObject(InstructorStore())
+        .environmentObject(SemesterStore())
 }

--- a/CourseCorrection/ContentView.swift
+++ b/CourseCorrection/ContentView.swift
@@ -49,6 +49,7 @@ struct ContentView: View {
                 .environmentObject(classItemStore)
                 .environmentObject(courseStore)
                 .environmentObject(instructorStore)
+                .environmentObject(semesterStore)
         }
         .overlay(alignment: .bottom) {
             Text(departmentStore.usingICloud ? "Stored in iCloud" : "Stored on Device")


### PR DESCRIPTION
## Summary
- add `SemesterStore` as an environment object for class item forms and views
- replace semester text field with a picker bound to the store
- pass `SemesterStore` through `ContentView`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_685214f6a45c8321bdff1bf945b65c59