### PR TITLE
Add CourseResultEntry management

### DIFF
--- a/CourseCorrection/ContentView.swift
+++ b/CourseCorrection/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     @StateObject private var subjectStore = SubjectStore()
     @StateObject private var courseStore = CourseStore()
     @StateObject private var classItemStore = ClassItemStore()
+    @StateObject private var courseResultEntryStore = CourseResultEntryStore()
 
     var body: some View {
         TabView {
@@ -49,6 +50,14 @@ struct ContentView: View {
                 .environmentObject(classItemStore)
                 .environmentObject(courseStore)
                 .environmentObject(instructorStore)
+                .environmentObject(semesterStore)
+            CourseResultEntriesView()
+                .tabItem {
+                    Label("Results", systemImage: "chart.bar")
+                }
+                .environmentObject(courseResultEntryStore)
+                .environmentObject(classItemStore)
+                .environmentObject(courseStore)
                 .environmentObject(semesterStore)
         }
         .overlay(alignment: .bottom) {

--- a/CourseCorrection/CourseResultEntriesView.swift
+++ b/CourseCorrection/CourseResultEntriesView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+struct CourseResultEntriesView: View {
+    @EnvironmentObject var store: CourseResultEntryStore
+    @EnvironmentObject var classItemStore: ClassItemStore
+    @EnvironmentObject var courseStore: CourseStore
+    @EnvironmentObject var semesterStore: SemesterStore
+    @State private var showingAdd = false
+
+    /// Groups entries by the semester of their associated class.
+    private var grouped: [(semester: Semester?, entries: [CourseResultEntry])] {
+        let dict = Dictionary(grouping: store.entries) { entry -> Semester? in
+            guard let item = classItemStore.classItems.first(where: { $0.id == entry.classID }),
+                  let semID = item.semesterID else { return nil }
+            return semesterStore.semesters.first(where: { $0.id == semID })
+        }
+        return dict.map { ($0.key, $0.value) }
+            .sorted { lhs, rhs in
+                switch (lhs.semester, rhs.semester) {
+                case let (l?, r?):
+                    return l.name < r.name
+                case (_?, nil):
+                    return true
+                case (nil, _?):
+                    return false
+                default:
+                    return true
+                }
+            }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(grouped, id: \.semester?.id) { group in
+                    Section(header: Text(group.semester?.name ?? "No Semester")) {
+                        ForEach(group.entries) { entry in
+                            if let item = classItemStore.classItems.first(where: { $0.id == entry.classID }),
+                               let course = courseStore.courses.first(where: { $0.id == item.courseID }) {
+                                NavigationLink("\(course.courseNumber) - \(course.title) : \(entry.courseResult?.description ?? "None")") {
+                                    EditCourseResultEntryView(entry: entry)
+                                        .environmentObject(store)
+                                        .environmentObject(classItemStore)
+                                        .environmentObject(courseStore)
+                                        .environmentObject(semesterStore)
+                                }
+                            }
+                        }
+                        .onDelete { offsets in
+                            let ids = offsets.map { group.entries[$0].id }
+                            store.remove(ids: ids)
+                        }
+                    }
+                }
+            }
+            .overlay {
+                if store.entries.isEmpty {
+                    ContentUnavailableView("No Results", systemImage: "chart.bar")
+                }
+            }
+            .navigationTitle("Results")
+            .toolbar { Button("Add") { showingAdd = true } }
+            .navigationBarTitleDisplayMode(.inline)
+            .sheet(isPresented: $showingAdd) {
+                AddCourseResultEntrySheet()
+                    .environmentObject(store)
+                    .environmentObject(classItemStore)
+                    .environmentObject(courseStore)
+            }
+        }
+    }
+}
+
+struct AddCourseResultEntrySheet: View {
+    @EnvironmentObject var store: CourseResultEntryStore
+    @EnvironmentObject var classItemStore: ClassItemStore
+    @EnvironmentObject var courseStore: CourseStore
+    @Environment(\.dismiss) var dismiss
+    @State private var newEntry = CourseResultEntry(classID: UUID(), courseResult: nil)
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                CourseResultEntryFormView(entry: $newEntry)
+                    .environmentObject(classItemStore)
+                    .environmentObject(courseStore)
+            }
+            .navigationTitle("New Result")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        store.add(newEntry)
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel", role: .cancel) { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+struct EditCourseResultEntryView: View {
+    @EnvironmentObject var store: CourseResultEntryStore
+    @EnvironmentObject var classItemStore: ClassItemStore
+    @EnvironmentObject var courseStore: CourseStore
+    @EnvironmentObject var semesterStore: SemesterStore
+    @Environment(\.dismiss) var dismiss
+
+    @State private var editedEntry: CourseResultEntry
+    private let originalEntry: CourseResultEntry
+
+    init(entry: CourseResultEntry) {
+        self._editedEntry = State(initialValue: entry)
+        self.originalEntry = entry
+    }
+
+    var body: some View {
+        Form {
+            CourseResultEntryFormView(entry: $editedEntry)
+                .environmentObject(classItemStore)
+                .environmentObject(courseStore)
+        }
+        .navigationTitle("Edit Result")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Save") { save() }
+                    .disabled(editedEntry == originalEntry)
+            }
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Cancel", role: .cancel) { dismiss() }
+            }
+        }
+    }
+
+    private func save() {
+        if let index = store.entries.firstIndex(where: { $0.id == originalEntry.id }) {
+            store.entries[index] = editedEntry
+            store.save()
+        }
+        dismiss()
+    }
+}
+
+#Preview {
+    CourseResultEntriesView()
+        .environmentObject(CourseResultEntryStore())
+        .environmentObject(ClassItemStore())
+        .environmentObject(CourseStore())
+        .environmentObject(SemesterStore())
+}

--- a/CourseCorrection/CourseResultEntry.swift
+++ b/CourseCorrection/CourseResultEntry.swift
@@ -75,7 +75,7 @@ enum LetterGrade: String, CaseIterable, Codable, Comparable {
 }
 
 /// Represents the overall course result/status: either a letter grade or a non-graded status.
-enum CourseResult: Codable {
+enum CourseResult: Codable, Equatable, Hashable {
     case grade(LetterGrade)
     case withdrawn     // "W"
     case incomplete    // "I"
@@ -116,6 +116,11 @@ enum CourseResult: Codable {
         case .pass:             return "Pass"
         case .noPass:           return "No Pass"
         }
+    }
+
+    /// All standard course result options including letter grades.
+    static var allOptions: [CourseResult] {
+        LetterGrade.orderedCases.map { .grade($0) } + [.withdrawn, .incomplete, .audit, .pass, .noPass]
     }
     
     /// Initialize from a string code, e.g. "B+", "W", "I", etc.

--- a/CourseCorrection/CourseResultEntryFormView.swift
+++ b/CourseCorrection/CourseResultEntryFormView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct CourseResultEntryFormView: View {
+    @EnvironmentObject var classItemStore: ClassItemStore
+    @EnvironmentObject var courseStore: CourseStore
+    @Binding var entry: CourseResultEntry
+
+    private var classOptions: [ClassItem] { classItemStore.classItems }
+
+    var body: some View {
+        Group {
+            Picker("Class", selection: $entry.classID) {
+                ForEach(classOptions) { item in
+                    if let course = courseStore.courses.first(where: { $0.id == item.courseID }) {
+                        Text("\(course.courseNumber) - \(course.title)").tag(item.id)
+                    }
+                }
+            }
+            Picker("Result", selection: $entry.courseResult) {
+                Text("None").tag(nil as CourseResult?)
+                ForEach(CourseResult.allOptions, id: \.self) { result in
+                    Text(result.description).tag(Optional(result))
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    CourseResultEntryFormView(entry: .constant(CourseResultEntry(classID: UUID(), courseResult: nil)))
+        .environmentObject(ClassItemStore())
+        .environmentObject(CourseStore())
+}

--- a/CourseCorrection/CourseResultEntryStore.swift
+++ b/CourseCorrection/CourseResultEntryStore.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+private let containerIdentifier = "iCloud.com.davin.CourseCorrection"
+
+/// Persists `CourseResultEntry` objects either in iCloud or locally.
+class CourseResultEntryStore: ObservableObject {
+    @Published var entries: [CourseResultEntry] = []
+    @Published var usingICloud: Bool
+
+    private let fileURL: URL
+
+    init() {
+        if let icloud = FileManager.default.url(forUbiquityContainerIdentifier: containerIdentifier) {
+            usingICloud = true
+            fileURL = icloud.appendingPathComponent("course_results.json")
+        } else {
+            usingICloud = false
+            fileURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("course_results.json")
+        }
+        load()
+    }
+
+    /// Loads stored entries from persistent storage.
+    func load() {
+        guard let data = try? Data(contentsOf: fileURL) else { return }
+
+        if let decoded = try? JSONDecoder().decode([CourseResultEntry].self, from: data) {
+            entries = decoded
+        }
+    }
+
+    /// Saves entries to persistent storage.
+    func save() {
+        do {
+            let data = try JSONEncoder().encode(entries)
+            try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try data.write(to: fileURL)
+        } catch {
+            print("Failed to save course results: \(error)")
+        }
+    }
+
+    /// Adds an entry and persists the change.
+    func add(_ entry: CourseResultEntry) {
+        entries.append(entry)
+        save()
+    }
+
+    /// Removes entries with the provided identifiers.
+    func remove(ids: [UUID]) {
+        entries.removeAll { ids.contains($0.id) }
+        save()
+    }
+}


### PR DESCRIPTION
## Summary
- make `CourseResult` hashable and add helper listing
- implement `CourseResultEntryStore` for persistence
- add forms and list views for course results grouped by semester
- add new results tab in `ContentView`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854b08113c8832195008d717d907fdb